### PR TITLE
temp/make-timestamps-optional

### DIFF
--- a/dist/models/shared.d.ts
+++ b/dist/models/shared.d.ts
@@ -1,7 +1,7 @@
 export declare namespace IShared {
     interface Timestamps {
-        createdAt: Date;
-        updatedAt: Date;
+        createdAt?: Date;
+        updatedAt?: Date;
     }
     interface GeneralMap<T> {
         [key: string]: T;

--- a/src/models/shared.ts
+++ b/src/models/shared.ts
@@ -8,8 +8,8 @@ import { Types } from 'mongoose'
 export namespace IShared {
 
     export interface Timestamps {
-        createdAt: Date
-        updatedAt: Date
+        createdAt?: Date
+        updatedAt?: Date
     }
 
 	/**


### PR DESCRIPTION
Making the createdAt and updatedAt fields in the Timestamps interface optional