### PR TITLE
john-daly/ch2152/update-the-calendar-model-to-include-a-reservationsettings

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "devDependencies": {
     "@types/mongoose": "^5.3.5",
+    "json-rules-engine-types": "https://git@github.com/meshhq/json-rules-engine-types.git#v0.0.2",
     "typescript": "^3.3.3"
   }
 }

--- a/src/models/calendar.ts
+++ b/src/models/calendar.ts
@@ -1,5 +1,6 @@
 // External Dependencies.
 import { Types } from 'mongoose'
+import * as JsonRules from 'json-rules-engine'
 
 // Sub Models.
 import Location from './subModels/shared/location'
@@ -26,7 +27,8 @@ namespace Calendar {
 		clubID?: Types.ObjectId,
 		groupID?: Types.ObjectId,
 		maxParticipants?: number | null
-		location?: Location.Model
+        location?: Location.Model
+        reservationSettings?: ReservationSetting[]
 	}
 
 	// --------------------------------
@@ -70,7 +72,22 @@ namespace Calendar {
 				end: string
 				reservations?: Event.Reservation[]
 		}
-	}
+    }
+    
+    export interface ReservationSetting {
+        isDefault: boolean
+        rules: ReservationSettingRules[]
+    }
+
+    export interface ReservationSettingRules extends JsonRules.RuleFields {
+        event: {
+            type: string,
+            params: {
+                successMessage: string,
+                failureMessage: string,
+            }
+        }
+    }
 
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,8 @@
 		"baseUrl": "./",
 		"paths": {
 			"@clubhub/*": ["./"]
-		}
+        },
+        "types": ["json-rules-engine-types"],
 	},
 	"exclude": [
 		"node_modules",


### PR DESCRIPTION
- Bringing in our custom type definitions for ‘json-rules-engine’
- Updating the Calendar model definitions to include ‘reservationSettings’ field