### PR TITLE
Moved vehicle fields to car meta

### DIFF
--- a/dist/models/event.d.ts
+++ b/dist/models/event.d.ts
@@ -52,13 +52,17 @@ declare namespace Event {
         rsvp?: boolean;
         paid?: boolean;
     }
-    type ReservationMeta = ReservationBaseMeta | CarReservationMeta;
+    type ReservationMeta = ReservationBaseMeta | CarReservationMeta | GolfReservationMeta;
     interface ReservationBaseMeta {
         notes: string;
     }
     interface CarReservationMeta extends ReservationBaseMeta {
         vehicleID: Types.ObjectId;
         type?: Types.ObjectId;
+    }
+    interface GolfReservationMeta extends ReservationBaseMeta {
+        golfCartCount?: number;
+        holeCount?: number;
     }
     enum TimeFieldType {
         Start = "start",

--- a/dist/models/subModels/car.d.ts
+++ b/dist/models/subModels/car.d.ts
@@ -6,6 +6,8 @@ declare namespace CarMeta {
         leadID?: string;
         tenantID?: string;
         pushToken?: string;
+        keySpots?: string;
+        stallNumbers?: string;
     }
     interface Vehicle {
         _id?: Types.ObjectId;
@@ -17,7 +19,6 @@ declare namespace CarMeta {
         color?: string;
         description?: string;
         vehicleNumber?: string;
-        stallNumber?: string;
         vin?: string;
     }
 }

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -73,7 +73,7 @@ namespace Event {
 		paid?: boolean
 	}
 	
-	export type ReservationMeta = ReservationBaseMeta | CarReservationMeta // This will be extended to include golf reservation meta etc...
+	export type ReservationMeta = ReservationBaseMeta | CarReservationMeta | GolfReservationMeta // This will be extended to include golf reservation meta etc...
 	
 	export interface ReservationBaseMeta {
 		notes: string
@@ -82,6 +82,11 @@ namespace Event {
 	export interface CarReservationMeta extends ReservationBaseMeta {
 		vehicleID: Types.ObjectId,
 		type?: Types.ObjectId
+	}
+
+	export interface GolfReservationMeta extends ReservationBaseMeta {
+		golfCartCount?: number
+		holeCount?: number
 	}
 
 	/**

--- a/src/models/subModels/car.ts
+++ b/src/models/subModels/car.ts
@@ -14,9 +14,11 @@ namespace CarMeta {
 	export interface Model {
 		_id?: Types.ObjectId
 		vehicles?: Vehicle[]
-		leadID?: string,
-		tenantID?: string,
+		leadID?: string
+		tenantID?: string
 		pushToken?: string
+		keySpots?: string
+		stallNumbers?: string
 	}
 
 	// --------------------------------
@@ -33,7 +35,6 @@ namespace CarMeta {
 		color?: string
 		description?: string
 		vehicleNumber?: string
-		stallNumber?: string
 		vin?: string
 	}
 }


### PR DESCRIPTION
- The fields 'stallNumbers' and 'keySpots' are now at path user.meta.car 