### PR TITLE
john-daly/ch2992/add-blockcalendar-back-to-event-model

### DIFF
--- a/dist/models/event.d.ts
+++ b/dist/models/event.d.ts
@@ -31,6 +31,7 @@ declare namespace Event {
         maxParticipants?: number;
         recurring?: number;
         displayInFeed?: boolean;
+        blockCalendar?: boolean;
     }
     enum RecurringFrequency {
         YEARLY = 0,

--- a/src/models/event.ts
+++ b/src/models/event.ts
@@ -43,7 +43,8 @@ namespace Event {
 		maxGuests?: number // The Max Number of Guests a member can bring to an event. 
 		maxParticipants?: number // The max number of people that can attend an event.
 		recurring?: number
-		displayInFeed?: boolean
+        displayInFeed?: boolean
+        blockCalendar?: boolean
 	}
 
 	// --------------------------------


### PR DESCRIPTION
Adding blockCalendar back to the Event model