### PR TITLE
temp/add-name-to-queryfilter

### DIFF
--- a/dist/models/queryFilter.d.ts
+++ b/dist/models/queryFilter.d.ts
@@ -2,6 +2,7 @@ import { Types } from 'mongoose';
 declare namespace QueryFilter {
     interface Model {
         _id?: Types.ObjectId;
+        name: string;
         clubID: Types.ObjectId;
         predicates: Array<NestedPredicate | Predicate>;
         resource: string;
@@ -28,6 +29,15 @@ declare namespace QueryFilter {
         lt = "$lt",
         lte = "$lte",
         ne = "$ne"
+    }
+    enum ComparisonOperatorLabel {
+        $eq = "=",
+        $gt = ">",
+        $gte = ">=",
+        $in = "in",
+        $lt = "<",
+        $lte = "<=",
+        $ne = "not equal"
     }
 }
 export default QueryFilter;

--- a/dist/models/queryFilter.js
+++ b/dist/models/queryFilter.js
@@ -17,5 +17,15 @@ var QueryFilter;
         ComparisonOperator["lte"] = "$lte";
         ComparisonOperator["ne"] = "$ne";
     })(ComparisonOperator = QueryFilter.ComparisonOperator || (QueryFilter.ComparisonOperator = {}));
+    var ComparisonOperatorLabel;
+    (function (ComparisonOperatorLabel) {
+        ComparisonOperatorLabel["$eq"] = "=";
+        ComparisonOperatorLabel["$gt"] = ">";
+        ComparisonOperatorLabel["$gte"] = ">=";
+        ComparisonOperatorLabel["$in"] = "in";
+        ComparisonOperatorLabel["$lt"] = "<";
+        ComparisonOperatorLabel["$lte"] = "<=";
+        ComparisonOperatorLabel["$ne"] = "not equal";
+    })(ComparisonOperatorLabel = QueryFilter.ComparisonOperatorLabel || (QueryFilter.ComparisonOperatorLabel = {}));
 })(QueryFilter || (QueryFilter = {}));
 exports.default = QueryFilter;

--- a/src/models/queryFilter.ts
+++ b/src/models/queryFilter.ts
@@ -9,6 +9,7 @@ namespace QueryFilter {
 
     export interface Model {
         _id?: Types.ObjectId
+        name: string
         clubID: Types.ObjectId
         predicates: Array<NestedPredicate | Predicate>
         resource: string
@@ -43,6 +44,16 @@ namespace QueryFilter {
         lt = '$lt',
         lte = '$lte',
         ne = '$ne',
+    }
+
+    export enum ComparisonOperatorLabel {
+        $eq = '=',
+        $gt = '>',
+        $gte = '>=',
+        $in = 'in',
+        $lt = '<',
+        $lte = '<=',
+        $ne = 'not equal',
     }
 }
 


### PR DESCRIPTION
- Adding ‘name’ field to QueryFilter
- Adding ComparisonOperatorLabel enum, which can be used by client to make comparison operators more user friendly looking