### PR TITLE
Updating core

### DIFF
--- a/dist/models/calendar.d.ts
+++ b/dist/models/calendar.d.ts
@@ -15,6 +15,7 @@ declare namespace Calendar {
         remoteID?: string;
         clubID?: Types.ObjectId;
         groupID?: Types.ObjectId;
+        userGroupID?: Types.ObjectId;
         maxParticipants?: number | null;
         location?: Location.Model;
         reservationSettings?: ReservationSetting[];

--- a/src/models/calendar.ts
+++ b/src/models/calendar.ts
@@ -27,6 +27,7 @@ namespace Calendar {
 		remoteID?: string
 		clubID?: Types.ObjectId,
 		groupID?: Types.ObjectId,
+		userGroupID?: Types.ObjectId,
 		maxParticipants?: number | null
 		location?: Location.Model
 		reservationSettings?: ReservationSetting[]


### PR DESCRIPTION
Adding UserGroupID to cals. 

This will allow us to restrict the visibility of calendars to a specific set of users that are in a group. Admins will have the ability to optionally create a calendar for all of their groups. 