### PR TITLE
john-daly/ch3250/add-duration-to-hoursofoperation-in-core

### DIFF
--- a/dist/models/calendar.d.ts
+++ b/dist/models/calendar.d.ts
@@ -62,7 +62,6 @@ declare namespace Calendar {
         isDefault: boolean;
         dateRangeStart: Date;
         dateRangeEnd: Date;
-        bookingDuration: number;
         maxGuestsAdmin: number;
         maxGuestsMember: number;
         publicBookings: boolean;

--- a/dist/models/shared.d.ts
+++ b/dist/models/shared.d.ts
@@ -58,6 +58,7 @@ declare namespace IShared {
         dayOfWeek: DayOfWeek;
         opens: Date;
         closes: Date;
+        duration: number;
     }
 }
 export default IShared;

--- a/src/models/calendar.ts
+++ b/src/models/calendar.ts
@@ -83,7 +83,6 @@ namespace Calendar {
 		isDefault: boolean
 		dateRangeStart: Date
 		dateRangeEnd: Date
-		bookingDuration: number
 		maxGuestsAdmin: number
 		maxGuestsMember: number
 		publicBookings: boolean

--- a/src/models/shared.ts
+++ b/src/models/shared.ts
@@ -108,6 +108,7 @@ namespace IShared {
         dayOfWeek: DayOfWeek,
         opens: Date,
         closes: Date,
+        duration: number,
     }
 }
 


### PR DESCRIPTION
- Removing ‘bookingDuration’ from ReservationSetting schema
- Adding ‘duration’ to HoursOfOperation