### PR TITLE
john-daly/ch3260/add-bookingduration-back-to-reservationsetting

### DIFF
--- a/dist/models/calendar.d.ts
+++ b/dist/models/calendar.d.ts
@@ -62,6 +62,7 @@ declare namespace Calendar {
         isDefault: boolean;
         dateRangeStart: Date;
         dateRangeEnd: Date;
+        bookingDuration: number;
         maxGuestsAdmin: number;
         maxGuestsMember: number;
         publicBookings: boolean;

--- a/src/models/calendar.ts
+++ b/src/models/calendar.ts
@@ -82,7 +82,8 @@ namespace Calendar {
 		name: string
 		isDefault: boolean
 		dateRangeStart: Date
-		dateRangeEnd: Date
+        dateRangeEnd: Date
+        bookingDuration: number
 		maxGuestsAdmin: number
 		maxGuestsMember: number
 		publicBookings: boolean


### PR DESCRIPTION
Adding ‘bookingDuration’ back onto the ReservationSetting interface