### PR TITLE
Adding public club info

### DIFF
--- a/dist/models/club.d.ts
+++ b/dist/models/club.d.ts
@@ -3,6 +3,7 @@ import User from './user';
 import Calendar from './calendar';
 import Location from './subModels/shared/location';
 import Image from './subModels/shared/image';
+import Section from './section';
 declare namespace Club {
     interface Model {
         _id?: Types.ObjectId;
@@ -33,9 +34,13 @@ declare namespace Club {
         image?: Image.Model;
         domain: string;
     }
+    interface PublicClubInfo {
+        club: Model;
+        sections: Section.Model[];
+    }
     enum Type {
-        Car = "CAR",
-        Golf = "GOLF",
+        Car = "Car",
+        Golf = "Golf",
         Tennis = "Tennis",
         Social = "Social",
         Yacht = "Yacht"

--- a/dist/models/club.js
+++ b/dist/models/club.js
@@ -4,8 +4,8 @@ var Club;
 (function (Club) {
     var Type;
     (function (Type) {
-        Type["Car"] = "CAR";
-        Type["Golf"] = "GOLF";
+        Type["Car"] = "Car";
+        Type["Golf"] = "Golf";
         Type["Tennis"] = "Tennis";
         Type["Social"] = "Social";
         Type["Yacht"] = "Yacht";

--- a/dist/models/section.d.ts
+++ b/dist/models/section.d.ts
@@ -11,6 +11,7 @@ declare namespace Section {
         orderingIndex: number;
         createdBy: Types.ObjectId;
         updatedBy: Types.ObjectId;
+        public?: boolean;
     }
     interface Page extends IShared.Timestamps {
         _id?: Types.ObjectId;

--- a/dist/service/club.d.ts
+++ b/dist/service/club.d.ts
@@ -4,4 +4,5 @@ export default class ClubService {
     client: ClubHubClient;
     constructor(client: ClubHubClient);
     getClubs: () => Promise<Club.UnprotectedModel[]>;
+    getPublicClubInfo: (domain: string) => Promise<Club.PublicClubInfo>;
 }

--- a/dist/service/club.js
+++ b/dist/service/club.js
@@ -45,6 +45,13 @@ var ClubService = (function () {
                     })];
             });
         }); };
+        this.getPublicClubInfo = function (domain) { return __awaiter(_this, void 0, void 0, function () {
+            return __generator(this, function (_a) {
+                return [2, this.client.get("clubs/" + domain).then(function (response) {
+                        return response.data;
+                    })];
+            });
+        }); };
         this.client = client;
     }
     return ClubService;

--- a/src/models/club.ts
+++ b/src/models/club.ts
@@ -8,6 +8,7 @@ import Calendar from './calendar'
 // Sub Documents.
 import Location from './subModels/shared/location'
 import Image from './subModels/shared/image'
+import Section from './section'
 
 namespace Club {
 
@@ -51,13 +52,21 @@ namespace Club {
 		domain: string
 	}
 
+	/**
+	 * PublicClubInfo contains the content for a public ClubHub website.
+	 */
+	export interface PublicClubInfo {
+		club: Model
+		sections: Section.Model[]
+	}
+
 	// --------------------------------
 	// Supporting Interfaces and Types
 	// --------------------------------
 
 	export enum Type {
-		Car = 'CAR',
-		Golf = 'GOLF',
+		Car = 'Car',
+		Golf = 'Golf',
 		Tennis = 'Tennis',
 		Social = 'Social',
 		Yacht = 'Yacht',

--- a/src/models/section.ts
+++ b/src/models/section.ts
@@ -20,6 +20,7 @@ namespace Section {
         orderingIndex: number
         createdBy: Types.ObjectId
         updatedBy: Types.ObjectId
+        public?: boolean
     }
 
 	// --------------------------------

--- a/src/service/club.ts
+++ b/src/service/club.ts
@@ -4,12 +4,7 @@ import * as axios from 'axios'
 // Client
 import ClubHubClient from '../client'
 import Club from 'src/models/club'
-import Section from 'src/models/section'
 
-export interface PublicClubInfo {
-    club: Club.UnprotectedModel
-    sections: Section.Model[]
-}
 /**
  * Interface to the ClubHub `Clubs` API.
  */
@@ -36,7 +31,7 @@ export default class ClubService {
     /**
      * Fetches all clubs. 
      */
-    public getPublicClubInfo = async (domain: string): Promise<PublicClubInfo> => {
+    public getPublicClubInfo = async (domain: string): Promise<Club.PublicClubInfo> => {
         return this.client.get(`clubs/${domain}`).then((response: axios.AxiosResponse) => {
             return response.data
         })

--- a/src/service/club.ts
+++ b/src/service/club.ts
@@ -4,7 +4,12 @@ import * as axios from 'axios'
 // Client
 import ClubHubClient from '../client'
 import Club from 'src/models/club'
+import Section from 'src/models/section'
 
+export interface PublicClubInfo {
+    club: Club.UnprotectedModel
+    sections: Section.Model[]
+}
 /**
  * Interface to the ClubHub `Clubs` API.
  */
@@ -24,6 +29,15 @@ export default class ClubService {
      */
     public getClubs = async (): Promise<Club.UnprotectedModel[]> => {
         return this.client.get('clubs').then((response: axios.AxiosResponse) => {
+            return response.data
+        })
+    }
+
+    /**
+     * Fetches all clubs. 
+     */
+    public getPublicClubInfo = async (domain: string): Promise<PublicClubInfo> => {
+        return this.client.get(`clubs/${domain}`).then((response: axios.AxiosResponse) => {
             return response.data
         })
     }


### PR DESCRIPTION
This PR adds a public club info interface. This interface value will be used by our new website service to build websites. 

It also adds the notion of Public to our sections. Admins will be able to create public sections in club info which will show up in the website. 